### PR TITLE
Add NSF-style metrics for downloads, emails, and HTCondor codebase

### DIFF
--- a/afs/extract_download_data.py
+++ b/afs/extract_download_data.py
@@ -1,0 +1,471 @@
+import logging
+import re
+import argparse
+import time
+from collections import OrderedDict, defaultdict
+from pathlib import Path
+from datetime import datetime
+
+logging.basicConfig(level=logging.WARNING)
+
+# important paths
+DL_LOGS_PATH = Path("/p/condor/public/license")
+NATIVE_FILE = DL_LOGS_PATH / "native-packages.mbox"
+
+# defaults
+OUTDIR = Path.cwd()
+START_TS = int(time.time()) - 3600*24*7
+END_TS = int(time.time())
+
+[WINDOWS, LINUX, MACOS, OTHER] = ["Windows", "Linux", "MacOS", "Other"]
+OS_MAP = [
+    ("winnt",   WINDOWS),
+    ("windows", WINDOWS),
+    ("winn50",  WINDOWS),
+    (r"\.deb$", LINUX),
+    ("_deb_",   LINUX),
+    (r"\.rpm$", LINUX),
+    ("linux",   LINUX),
+    ("rhel",    LINUX),
+    ("rhap",    LINUX),
+    ("rhas",    LINUX),
+    ("fedora",  LINUX),
+    ("redhat",  LINUX),
+    ("centos",  LINUX),
+    ("ubuntu",  LINUX),
+    ("debian",  LINUX),
+    (r"mac ?os ?x?", MACOS),
+    ("irix",    OTHER),
+    ("dux",     OTHER),
+    ("solaris", OTHER),
+    ("sun4u_sol_",  OTHER),
+    ("aix",     OTHER),
+    ("hpux",    OTHER),
+    ("bsd",     OTHER),
+    ("vax-openvms", OTHER),
+    ("ydl3",    LINUX),
+    ("yd5",     LINUX),
+    ("all",     "All"),
+    ("_sl_",    LINUX),
+    ("sles",    LINUX),
+    ("_sol_",   LINUX),
+    (r"\.orig\.tar\.[gx]z", LINUX),
+    (r"-src\.tar\.[gbx]z2?", "All"),
+]
+os_map_temp = OrderedDict()
+for (os_re, os_str) in OS_MAP:
+    os_map_temp[re.compile(os_re, re.IGNORECASE)] = os_str
+OS_MAP = os_map_temp
+
+[X86, X86_64, OTHER] = ["x86", "x86-64", "Other"]
+ARCH_MAP = [
+    (r"linux-x86-g?libc", X86),
+    ("linux-x86.tar",     X86),
+    ("linux-x86-redhat",  X86),
+    ("linux-x86-rhel",    X86),
+    ("linux-x86-debian",  X86),
+    ("winnt-x86-5.0",     X86),
+    ("amd64",  X86_64),
+    ("x86_64", X86_64),
+    ("i386",   X86),
+    ("i686",   X86),
+    ("x64",    X86_64),
+    ("ia64",   OTHER),
+    ("ppc64",  OTHER),
+    ("sun4u",  OTHER),
+    ("sparc",  OTHER),
+    ("alpha",  OTHER),
+    ("-ppc-",  OTHER),
+    ("ppc_aix", OTHER),
+    ("hppar",  OTHER),
+    ("sgi",    OTHER),
+    ("powerpc", OTHER),
+    ("vax-openvms", OTHER),
+    (r"aix.*aix", OTHER),
+    ("x86-dynamic", X86),
+    (r"x86\.exe",   X86),
+    (r"x86\.zip",   X86),
+    (r"x86\.msi",   X86),
+    (r"x86\.tar",   X86),
+    ("-all-all", "All"),
+    ("-x86_rhap",   X86),
+    ("-x86_rhas",   X86),
+    ("-x86_redhat", X86),
+    ("-x86_deb",    X86),
+    ("-x86_sl",     X86),
+    ("-x86_freebsd", X86),
+    ("-x86_macos",  X86),
+    ("-x86_centos", X86),
+    (r"\.src\.",  "All"),
+    (r"^all$",    "All"),
+    (r"\.(orig|debian)\.tar\.[gx]z", "All"),
+    (r"-src\.tar\.[gbx]z2?", "All"),
+]
+arch_map_temp = OrderedDict()
+for (arch_re, arch_str) in ARCH_MAP:
+    arch_map_temp[re.compile(arch_re, re.IGNORECASE)] = arch_str
+ARCH_MAP = arch_map_temp
+
+def get_os(filename):
+    for os_re, os_str in OS_MAP.items():
+        match = os_re.search(filename)
+        if match:
+            return os_str
+    return "Unknown"
+
+def get_arch(filename):
+    for arch_re, arch_str in ARCH_MAP.items():
+        match = arch_re.search(filename)
+        if match:
+            return arch_str
+    return "Unknown"
+
+def get_log_files(log_path):
+    sendfile_re = re.compile(r"sendfile-v\d+\.\d+")
+    log_files = []
+    for log_file in log_path.glob("sendfile-v*"):
+        if sendfile_re.match(log_file.name):
+            log_files.append(log_file)
+    return log_files
+
+def read_log_file(log_file, data_out, args):
+    # 1551455077	END	condor-8.9.0-462330-Windows-x64.zip	...
+    re_binary = re.compile(r"h?t?condor-([\d.]+\d)(?:_preview)?[-.](.*)")
+    re_source = re.compile(r"h?t?condor_src-([\d.]+\d)(?:_preview)?[-.](.*)")
+    re_binary_deb = re.compile(r"h?t?condor_([\d.]+\d)-(.*\.deb)")
+    headers = ["timestamp", "status", "filename"]
+
+    logging.info(f"Opening {log_file.name}")
+    with open(log_file) as f:
+        n = 0
+        stored = 0
+        for line in f:
+            n += 1
+            cols = line.rstrip().split()
+            data = dict(zip(headers, cols[:len(headers)]))
+            logging.debug(f"Got line {data}")
+
+            if int(data["timestamp"]) < args.start or int(data["timestamp"]) > args.end:
+                logging.debug(f"Skipping date {data['timestamp']}")
+                continue
+
+            if data["status"] != "END":
+                logging.debug(f"Skipping status {data['status']}")
+                continue
+            if "sha256sum" in data["filename"]:
+                logging.debug(f"Skipping file {data['filename']}")
+                continue
+            if data["filename"].startswith("condordebugsyms"):
+                logging.debug(f"Skipping file {data['filename']}")
+                continue
+            if data["filename"].startswith("condor-drone-"):
+                logging.debug(f"Skipping file {data['filename']}")
+                continue
+
+            if data["filename"].startswith("condor-") or data["filename"].startswith("htcondor-"):
+                contents = "binary"
+                match = re_binary.match(data["filename"])
+                logging.debug(f"{data['filename']} is a binary file")
+            elif data["filename"].startswith("condor_src-") or data["filename"].startswith("htcondor_src-"):
+                contents = "source"
+                match = re_source.match(data["filename"])
+                logging.debug(f"{data['filename']} is a source file")
+            elif re_binary_deb.match(data["filename"]):
+                contents = "binary"
+                match = re_binary_deb.match(data["filename"])
+                logging.debug(f"{data['filename']} is a binary deb file")
+            else:
+                logging.error(f"Unparseable filename at {log_file.name}:{n}: {data['filename']}")
+                logging.debug(f"Skipping file {data['filename']}")
+                continue
+            if match is None:
+                logging.error(f"Unparseable {contents} filename at {log_file.name}:{n}: {data['filename']}")
+                logging.debug(f"Skipping file {data['filename']}")
+                continue
+
+            version = match.group(1)
+            logging.debug(f"Got version {version}")
+
+            version_major = ".".join(version.split(".")[0:2])
+            logging.debug(f"Got major version {version_major}")
+            if "." not in version_major or len(version_major) < 3:
+                logging.error(f"Weird version {version} at {log_file.name}:{n}: {data['filename']}")
+                logging.debug(f"Skipping file {data['filename']}")
+                continue
+
+            os = get_os(data["filename"])
+            logging.debug(f"Got OS {os}")
+            if os == "Unknown":
+                logging.warning(f"Dubious OS found at {log_file.name}:{n}: {data['filename']}")
+
+            arch = get_arch(data["filename"])
+            logging.debug(f"Got Arch {arch}")
+            if arch == "Unknown":
+                logging.warning(f"Dubious Arch found at {log_file.name}:{n}: {data['filename']}")
+
+            # Get a datetime with only the date
+            dt = datetime.fromtimestamp(int(data["timestamp"]))
+            date = datetime(dt.year, dt.month, dt.day)
+
+            # Store data
+            data_out[date]["version"][version] += 1
+            data_out[date]["version_major"][version_major] += 1
+            data_out[date]["osarch"][f"{os}/{arch}"] += 1
+            data_out[date]["os"][os] += 1
+            stored += 1
+
+    logging.info(f"Read {n} lines from {log_file.name}")
+    logging.info(f"Stored {stored} lines from {log_file.name}")
+    return
+
+def read_native_file(native_file, args):
+    # data is three level defaultdict with int data:
+    # 1. date (datetime.datetime)
+    # 2. bin type ("version", "version_major", "osarch", "os")
+    # 3. bin name ("8.9.12", "8.9", "Linux/x86_64", "Linux")
+    # e.g. 42 downloads on 2021-03-10:
+    # data[datetime.datetime(2021, 03, 10)]["version"]["8.9.12"] = 42
+    data = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+
+    re_rpm = re.compile(r"/.*/h?t?condor-([\d.]+\d)-.*\.(x86_64|i386|i686|ia64)\.rpm \((\d+) hits?\)")
+    re_src_rpm = re.compile(r"/.*/h?t?condor-([\d.]+\d)-(.*)\.src\.rpm \((\d+) hits?\)")
+
+    re_deb = re.compile(r"/.*/h?t?condor[_-]([\d.]+\d)-.*_(amd64|i386|all)\.deb \((\d+) hits?\)")
+    re_src_deb = re.compile(r"/.*/h?t?condor[_-]([\d.]+\d)-.*\.(orig|debian)\.tar\.[xg]z \((\d+) hits?\)")
+
+    re_tarball = re.compile(r"/.*/tarball/.*/(h?t?condor[-_][\d.]+\d[-.][^/ ]+) \((\d+) hits?\)")
+    re_src_tarball = re.compile(r"/.*/tarball/.*/(h?t?condor_src[-_][\d.]+\d[-.][^/ ]+) \((\d+) hits?\)")
+    re_binary = re.compile(r"h?t?condor-([\d.]+\d)(?:_preview)?[-.](.*)")
+    re_source = re.compile(r"h?t?condor_src-([\d.]+\d)(?:_preview)?[-.](.*)")
+    re_binary_deb = re.compile(r"h?t?condor_([\d.]+\d)-(.*\.deb)")
+    re_source_deb = re.compile(r"h?t?condor_([\d.]+\d)\..*(orig|debian)\.tar\.[xg]z")
+
+    date = None
+    in_header = True
+    with open(native_file) as f:
+        n = 0
+        emails = 0
+        paths = 0
+        stored = 0
+        for line in f:
+            n += 1
+            if len(line) >= 5 and line[:5] == "From ":
+                logging.info(f"Got new email {line.rstrip()}")
+                emails += 1
+                date = None
+                date_warning = False
+                in_header = True
+                continue
+            elif "From " in line:
+                # If "From " occurs elsewhere, it could be a sign of interleaved reports
+                logging.error(f"Possible corruption at {native_file.name}:{n}")
+                continue
+            elif len(line) >= 5 and line[:5] == "Date:":
+                if (date is not None) or not in_header:
+                    logging.warning(f'Got unexpected "Date:" header at {native_file.name}:{n}')
+                try:
+                    # Date: Sat, 06 Mar 2021 02:30:32 -0600 (CST)
+                    date = datetime.strptime(line.split(":")[1].strip(), "%a, %d %b %Y %H")
+                except ValueError:
+                    logging.error(f"Could not parse date at {native_file.name}:{n}: {line.rstrip()}")
+                date = datetime(date.year, date.month, date.day)
+                continue
+            elif in_header and line.strip() == "":
+                if date is None:
+                    logging.warning(f"Did not find date in header at {native_file.name}:{n}")
+                in_header = False
+                continue
+            elif in_header:
+                continue
+            elif date.timestamp() < args.start or date.timestamp() > args.end:
+                if not date_warning:
+                    logging.debug(f"Skipping email due to date")
+                    date_warning = True
+                continue
+
+            # Only consider lines that are paths
+            if line.startswith('/') and line.split('/')[1] in ["s", "condor", "htcondor"]:
+                paths += 1
+                logging.debug(f"Attempting match against {line.rstrip()}")
+            else:
+                continue
+
+            # Try matching binary packages first
+            if re_rpm.match(line.rstrip()) or re_deb.match(line.rstrip()):
+                match = re_rpm.match(line.rstrip()) or re_deb.match(line.rstrip())
+                logging.debug(f"Got binary package match: {match.groups()}")
+
+                (version, arch_str, hits) = match.groups()
+                version_major = ".".join(version.split(".")[0:2])
+
+                os = "Linux"
+                arch = get_arch(arch_str)
+                if arch == "Unknown":
+                    logging.warning(f"Dubious Arch found at {native_file.name}:{n}: {line.rstrip()}")
+
+            # Try matching source packages second
+            elif re_src_rpm.match(line.rstrip()) or re_src_deb.match(line.rstrip()):
+                match = re_src_rpm.match(line.rstrip()) or re_src_deb.match(line.rstrip())
+                logging.debug(f"Got source package match: {match.groups()}")
+
+                (version, dummy, hits) = match.groups()
+                version_major = ".".join(version.split(".")[0:2])
+
+                os = "Linux"
+                arch = "All"
+
+            # Try matching tarballs last
+            elif re_tarball.match(line.rstrip()) or re_src_tarball.match(line.rstrip()):
+                match = re_tarball.match(line.rstrip()) or re_src_tarball.match(line.rstrip())
+                logging.debug(f"Got tarball match: {match.groups()}")
+
+                (filename, hits) = match.groups()
+
+                if "sha256sum" in filename:
+                    logging.debug(f"Skipping file {filename}")
+                    continue
+
+                if filename.startswith("condor-") or filename.startswith("htcondor-"):
+                    contents = "binary"
+                    match = re_binary.match(filename)
+                elif filename.startswith("condor_src-") or filename.startswith("htcondor_src-"):
+                    contents = "source"
+                    match = re_source.match(filename)
+                elif re_binary_deb.match(filename):
+                    contents = "binary"
+                    match = re_binary_deb.match(filename)
+                elif re_source_deb.match(filename):
+                    contents = "source"
+                    match = re_source_deb.match(filename)
+                else:
+                    logging.error(f"Unparseable filename at {native_file.name}:{n}: {line.rstrip()}")
+                    continue
+                if match is None:
+                    logging.error(f"Unparseable {contents} filename at {native_file.name}:{n}: {line.rstrip()}")
+                    continue
+
+                version = match.group(1)
+                version_major = ".".join(version.split(".")[0:2])
+
+                os = get_os(filename)
+                logging.debug(f"Got OS {os}")
+                if os == "Unknown":
+                    logging.warning(f"Dubious OS found at {native_file.name}:{n}: {line.rstrip()}")
+
+                arch = get_arch(filename)
+                logging.debug(f"Got Arch {arch}")
+                if arch == "Unknown":
+                    logging.warning(f"Dubious Arch found at {native_file.name}:{n}: {line.rstrip()}")
+
+            # Give up
+            else:
+                logging.debug(f"Did not find match for {line.rstrip()}")
+                continue
+
+            data[date]["version"][version] += int(hits)
+            data[date]["version_major"][version_major] += int(hits)
+            data[date]["osarch"][f"{os}/{arch}"] += int(hits)
+            data[date]["os"][os] += int(hits)
+            stored += 1
+
+    logging.info(f"Read {n} lines from {native_file.name}")
+    logging.info(f"Read {emails} emails from {native_file.name}")
+    logging.info(f"Read {paths} filepaths from {native_file.name}")
+    logging.info(f"Stored {stored} lines from {native_file.name}")
+
+    return data
+
+def get_keys(data):
+    versions_major = set()
+    versions = set()
+    oss = set()
+    osarchs = set()
+
+    for date in data.keys():
+        versions_major.update(list(data[date]["version_major"].keys()))
+        versions.update(list(data[date]["version"].keys()))
+        oss.update(list(data[date]["os"].keys()))
+        osarchs.update(list(data[date]["osarch"].keys()))
+
+    versions_major = list(versions_major)
+    versions = list(versions)
+    oss = list(oss)
+    osarchs = list(osarchs)
+
+    versions_major.sort(key=lambda v: list(map(int, v.split("."))))
+    versions.sort(key=lambda v: list(map(int, v.split("."))))
+    oss.sort()
+    osarchs.sort()
+
+    return {"version_major": versions_major, "version": versions, "os": oss, "osarch": osarchs}
+
+def write_csvs(data, args):
+    dates = list(data.keys())
+    dates.sort()
+
+    keys = get_keys(data)
+
+    fs = {
+        # non-cumulative
+        "version_major": open(args.outdir / "downloads_by_version_major.csv", "w"),
+        "version":       open(args.outdir / "downloads_by_version.csv", "w"),
+        "os":            open(args.outdir / "downloads_by_os.csv", "w"),
+        "osarch":        open(args.outdir / "downloads_by_arch.csv", "w"),
+        # cumulative
+        "cum_version_major": open(args.outdir / "cumulative_downloads_by_version_major.csv", "w"),
+        "cum_version":       open(args.outdir / "cumulative_downloads_by_version.csv", "w"),
+        "cum_os":            open(args.outdir / "cumulative_downloads_by_os.csv", "w"),
+        "cum_osarch":        open(args.outdir / "cumulative_downloads_by_arch.csv", "w"),
+    }
+
+    # write headers
+    for (keyname, f) in fs.items():
+        f.write(f"Date,{','.join([col for col in keys[keyname.lstrip('cum_')]])},Total\n")
+
+    # write data
+    total_total = 0
+    for date in dates:
+        # skip dates outside of range
+        if not (date.timestamp() >= args.start and date.timestamp() <= args.end):
+            continue
+        for (keyname, f) in fs.items():
+            f.write(f"{date.strftime('%Y-%m-%d')},")
+            if keyname.startswith("cum_"):
+                # accumulate and write
+                for key in keys[keyname.lstrip("cum_")]:
+                    data["cum"][keyname][key] += data[date][keyname.lstrip("cum_")][key]
+                total = sum([data["cum"][keyname][key] for key in keys[keyname.lstrip("cum_")]])
+                f.write(f"{','.join([str(data['cum'][keyname][key]) for key in keys[keyname.lstrip('cum_')]])},{total}\n")
+            else:
+                # write
+                total = sum([data[date][keyname][key] for key in keys[keyname]])
+                f.write(f"{','.join([str(data[date][keyname][key]) for key in keys[keyname]])},{total}\n")
+            if keyname == "os":
+                total_total += total
+
+    with open(args.outdir / "download_data.txt", "w") as f:
+        f.write(f"From {datetime.fromtimestamp(args.start)} to {datetime.fromtimestamp(args.end)}:\n")
+        f.write(f"HTCondor packages, compiled tarballs, and source code tarballs\n")
+        f.write(f"were downloaded {total_total} times.\n")
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--outdir", default=OUTDIR, metavar="PATH", type=Path, help="Output directory, defaults to CWD (%(default)s)")
+    parser.add_argument("--start", default=START_TS, metavar="TIMESTAMP", type=int, help="Starting timestamp, defaults to one week ago (%(default)d)")
+    parser.add_argument("--end", default=END_TS, metavar="TIMESTAMP", type=int, help="Ending timestamp, defaults to now (%(default)d)")
+    parser.add_argument("--log_level", metavar="LEVEL", default="WARNING", help="Log level, defaults to %(default)s")
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parse_args()
+    logging.getLogger().setLevel(getattr(logging, args.log_level.upper(), logging.WARNING))
+    data = read_native_file(NATIVE_FILE, args)
+    log_files = get_log_files(DL_LOGS_PATH)
+    for log_file in log_files:
+        read_log_file(log_file, data, args)
+    write_csvs(data, args)
+
+if __name__ == "__main__":
+    main()
+

--- a/afs/extract_git_data.py
+++ b/afs/extract_git_data.py
@@ -1,0 +1,113 @@
+import sys
+import logging
+import argparse
+import subprocess
+import shlex
+import shutil
+import time
+import re
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+
+OUTDIR = Path.cwd()
+START_TS = int(time.time()) - 3600*24*7
+END_TS = int(time.time())
+
+def get_git_logs(args):
+    after = datetime.fromtimestamp(args.start).strftime("%B.%d.%Y")
+    before = datetime.fromtimestamp(args.end).strftime("%B.%d.%Y")
+    cmd = f'git --git-dir="{args.repo_dir}/.git" log --all --numstat --pretty="%ae" --after {{{after}}} --before {{{before}}}'
+    logging.info(f"Running {cmd}")
+    result = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE, timeout=180)
+    try:
+        result.check_returncode()
+    except subprocess.CalledProcessError:
+        logging.exception(f"Error while trying to run {cmd}")
+        sys.exit(1)
+    return result.stdout.decode("utf-8")
+
+def get_total_loc(args):
+    cmd = f'./lines-of-code.sh "{args.repo_dir}"'
+    logging.info(f"Running {cmd}")
+    result = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE, timeout=180)
+    try:
+        result.check_returncode()
+    except subprocess.CalledProcessError:
+        logging.exception(f"Error while trying to run {cmd}")
+        sys.exit(1)
+
+    loc = 0
+    for line in result.stdout.decode("utf-8").split("\n"):
+        if line.split(":")[0] in ["src", "bindings"]:
+            # only count files in "src/" or "bindings"
+            loc += int(line.split()[1])
+
+    return loc
+
+def parse_logs_and_write_output(git_logs, total_loc, args):
+    commits = 0
+    authors = set()
+    lines_added = 0
+    lines_removed = 0
+    files = 0
+    unique_files = set()
+
+    previous_line = ""
+    new_commit = True
+    for line in git_logs.split("\n"):
+        cols = line.split()
+        if len(cols) == 0 or cols[0] == "":
+            pass
+        elif len(cols) == 1:
+            # author line(s)
+            if new_commit:
+                commits += 1
+                new_commit = False
+            # don't add automated github authors
+            if not ("github" in cols[0]):
+                authors.add(cols[0])
+        else:
+            # should be a file line, try parsing it
+            new_commit = True
+            try:
+                if cols[2].split("/")[0] in ["src", "bindings"]:
+                    # only count files in "src/" or "bindings/"
+                    lines_added += int(cols[0])
+                    lines_removed += int(cols[1])
+                    unique_files.add(cols[2])
+                    files += 1
+            except ValueError:
+                pass
+
+        previous_line = line
+
+    with open(args.outdir / "git_data.txt", "w") as f:
+        f.write(f"From {datetime.fromtimestamp(args.start)} to {datetime.fromtimestamp(args.end)}:\n")
+        f.write(f"{len(authors)} contributors\n")
+        f.write(f"made {commits} source code commits,\n")
+        f.write(f"consisting of {files} ({len(unique_files)} unique) file modifications\n")
+        f.write(f"adding {lines_added} lines of code (LOC)\n")
+        f.write(f"and removing {lines_removed} LOC.\n")
+        f.write(f"Total LOC stands at {total_loc}.\n")
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--outdir", default=OUTDIR, metavar="PATH", type=Path, help="Output directory, defaults to CWD (%(default)s)")
+    parser.add_argument("--start", default=START_TS, metavar="TIMESTAMP", type=int, help="Starting timestamp, defaults to one week ago (%(default)d)")
+    parser.add_argument("--end", default=END_TS, metavar="TIMESTAMP", type=int, help="Ending timestamp, defaults to now (%(default)d)")
+    parser.add_argument("--log_level", metavar="LEVEL", default="WARNING", help="Log level, defaults to %(default)s")
+    parser.add_argument("--repo_dir", metavar="PATH", type=Path, required=True,
+        help="Path to existing CONDOR_SRC repository. Must be updated and set to correct branch.")
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parse_args()
+    logging.getLogger().setLevel(getattr(logging, args.log_level.upper(), logging.WARNING))
+    git_logs = get_git_logs(args)
+    total_loc = get_total_loc(args)
+    parse_logs_and_write_output(git_logs, total_loc, args)
+
+if __name__ == "__main__":
+    main()

--- a/afs/extract_htcondor_users_data.py
+++ b/afs/extract_htcondor_users_data.py
@@ -1,0 +1,169 @@
+import logging
+import re
+import argparse
+import time
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+logging.basicConfig(level=logging.WARNING)
+
+ARCHIVE_DIR = Path("/p/list-archives/htcondor-users")
+
+OUTDIR = Path.cwd()
+START_TS = int(time.time()) - 3600*24*7
+END_TS = int(time.time())
+
+def is_staff(addr):
+    addr = addr.lower()
+
+    # Crudely assume anyone from cs.wisc.edu is staff
+    if addr[-12:] == "@cs.wisc.edu":
+        return True
+    else: # Handle other known cases
+        others = {
+            "dan@help.wisc.edu",
+            "jcpatton@wisc.edu",
+            "lmichael@wisc.edu",
+            "ckoch5@wisc.edu",
+            "karpel@wisc.edu",
+            "egrasmick@wisc.edu",
+            "moate@gmail.com",
+        }
+        return addr in others
+
+def is_edu(addr):
+    addr = addr.lower()
+    if addr[-4:] == ".edu":
+        return True
+    else: # Handle other known cases
+        others = {
+            "moate@gmail.com",
+        }
+        return addr in others
+
+def is_ac(addr):
+    addr = addr.lower()
+    if ".ac." in addr.split("@")[-1]:
+        return True
+    else: # Handle other known cases
+        others = {}
+        return addr in others
+
+def get_data(args):
+    # data is two level defaultdict with int data:
+    # 1. date (datetime.datetime)
+    # 2. sender origin (all, staff, edu, ac)
+    data = defaultdict(lambda: defaultdict(int))
+
+    origins = {
+        "total": lambda x: True,
+        "staff": is_staff,
+        "edu"  : is_edu,
+        "ac"   : is_ac,
+    }
+
+    start_dt = datetime.fromtimestamp(args.start)
+    end_dt = datetime.fromtimestamp(args.end)
+
+    start_month = datetime(start_dt.year, start_dt.month, 1)
+    end_month = datetime(end_dt.year, end_dt.month, 1)
+
+    files = 0
+    total = 0
+    for mbox_file in ARCHIVE_DIR.glob("*.txt"):
+
+        # only read files that could contain emails in the date range
+        try:
+            mbox_month = datetime.strptime(mbox_file.stem, "%Y-%B")
+        except ValueError:
+            logging.info(f"Skipping {mbox_file.name}")
+            continue
+        if mbox_month < start_month or mbox_month > end_month:
+            logging.info(f"Skipping {mbox_file.name}, out of date range")
+            continue
+
+
+        logging.info(f"Opening {mbox_file.name}")
+        with open(mbox_file, "rb") as f:
+            files += 1
+            n = 0
+            for line in f:
+                n += 1
+
+                #  0    1             2   3   4  5        6
+                # "From user@foo.edu  Mon Dec 31 23:59:59 1999"
+                #  0             1            2           3
+                #  123456   78  90  1 234567890 12 34567890123
+                if len(line) < 33 or line[:5] != b"From ":
+                    continue
+                tokens = line.decode("utf-8").rstrip().split()
+
+                # Auto-responders, booooo
+                if tokens[1] == "MAILER-DAEMON":
+                    logging.debug(f"Skipping MAILER-DAEMON: {line.rstrip()}")
+                    continue
+
+                # Text that starts with "From " should be escaped,
+                # but let's add a few checks just in case
+                if "@" not in tokens[1] or len(tokens) != 7:
+                    logging.warning(f"Skipped potential From line at {mbox_file.name}:{n}: {line.rstrip()}")
+                    continue
+
+                logging.debug(f"Parsing {line.rstrip()}")
+                addr = tokens[1]
+                date_str = " ".join(tokens[3:]) # skip day of week
+                dt = datetime.strptime(date_str, "%b %d %H:%M:%S %Y")
+
+                if dt < start_dt or dt > end_dt:
+                    logging.debug(f"Skipped {line.rstrip()}: out of date range")
+                    continue
+
+                total += 1
+                date = datetime(dt.year, dt.month, dt.day) # reduce date to day
+                for origin, test in origins.items():
+                    data[date][origin] += int(test(addr))
+                    if origin != "total" and test(addr):
+                        logging.debug(f"Counted {addr} as {origin}")
+
+    logging.info(f"Opened {files} mbox files")
+    logging.info(f"Counted {total} emails")
+    return data
+
+def write_csv(data, args):
+    dates = list(data.keys())
+    dates.sort()
+
+    cols = ["edu", "ac", "staff", "total"]
+
+    total = 0
+    staff = 0
+    with open(args.outdir / "htcondor-users_emails_by_origin.csv", "w") as f:
+        f.write(f"date,{','.join(cols)}\n")
+        for date in dates:
+            f.write(f"{date.strftime('%Y-%m-%d')},{','.join([str(data[date][col]) for col in cols])}\n")
+            total += data[date]["total"]
+            staff += data[date]["staff"]
+
+    with open(args.outdir / "htcondor-users_data.txt", "w") as f:
+        f.write(f"From {datetime.fromtimestamp(args.start)} to {datetime.fromtimestamp(args.end)}:\n")
+        f.write(f"Our community-support email list htcondor-users saw {total} messages,\n")
+        f.write(f"of which PATh staff sent {staff} emails responding to user questions.\n")
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--outdir", default=OUTDIR, metavar="PATH", type=Path, help="Output directory, defaults to CWD (%(default)s)")
+    parser.add_argument("--start", default=START_TS, metavar="TIMESTAMP", type=int, help="Starting timestamp, defaults to one week ago (%(default)d)")
+    parser.add_argument("--end", default=END_TS, metavar="TIMESTAMP", type=int, help="Ending timestamp, defaults to now (%(default)d)")
+    parser.add_argument("--log_level", metavar="LEVEL", default="WARNING", help="Log level, defaults to %(default)s")
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parse_args()
+    logging.getLogger().setLevel(getattr(logging, args.log_level.upper(), logging.WARNING))
+    data = get_data(args)
+    write_csv(data, args)
+
+if __name__ == "__main__":
+    main()

--- a/afs/extract_rt_stats.py
+++ b/afs/extract_rt_stats.py
@@ -1,0 +1,166 @@
+import logging
+import sys
+import time
+import argparse
+import requests
+from datetime import datetime, timedelta
+from pathlib import Path
+
+logging.basicConfig(level=logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.ERROR)
+
+OUTDIR = Path.cwd()
+START_TS = int(time.time()) - 3600*24*7
+END_TS = int(time.time())
+
+def get_session(args):
+    # create a session and get initial cookie
+    auth_data = {
+        "user": args.username,
+        "pass": args.password_file.open().read().rstrip()
+    }
+    session = requests.Session()
+    logging.info(f"Opening session with {args.api_uri} with username {args.username}")
+    response = session.post(args.api_uri, params=auth_data)
+    response.raise_for_status()
+    return session
+
+def parse_response(response):
+    # function to parse API responses "key: value\n" into dicts
+    data = {}
+    for line in response.text.split("\n"):
+        tokens = line.split(":")
+        if len(tokens) < 2:
+            continue
+        (key, value) = (tokens[0], ':'.join(tokens[1:]).lstrip().rstrip())
+        data[key] = value
+    return data
+
+def get_and_write_data(session, args):
+
+    # put start and end dates in format understood by query API
+    since = datetime.fromtimestamp(args.start).strftime("%Y-%m-%d %H:%M:%S")
+    until = datetime.fromtimestamp(args.end).strftime("%Y-%m-%d %H:%M:%S")
+
+    for queue in args.queues:
+
+        # initialize queue stats
+        tickets_created = 0
+        tickets_assigned = 0
+        emails_recv = 0
+        emails_sent = 0
+        response_times = []
+
+        # search queue for all tickets from the "since" date
+        query = f"(Updated >= '{since}' AND Created <= '{until}') AND Queue = '{queue}'"
+        logging.debug(f'Querying /search/ticket for "{query}"')
+        response = session.get(args.api_uri + "/search/ticket", params={"query": query})
+        response.raise_for_status()
+        tickets = parse_response(response)
+        logging.info(f"Got {len(tickets)} tickets")
+
+        for ticket in tickets.keys():
+
+            # initialize per-ticket placeholders
+            created = False
+            assigned = False
+            last_recv = None
+
+            logging.debug(f"Getting historical events for #{ticket}")
+            response = session.get(args.api_uri + f"/ticket/{ticket}/history")
+            response.raise_for_status()
+            history = parse_response(response)
+            logging.debug(f"Got {len(history)} events from #{ticket}")
+
+            # loop over history in order
+            history_ids = list(history.keys())
+            history_ids.sort()
+            for history_id in history_ids:
+
+                # first two words in the history log define the ticket type
+                ticket_type = " ".join(history[history_id].split()[:2])
+                logging.debug(f'#{ticket} entry {history_id} is of type "{ticket_type}"')
+
+                # check if ticket created during time period
+                if ticket_type == "Ticket created":
+                    created = True
+                    response = session.get(args.api_uri + f"/ticket/{ticket}/history/id/{history_id}")
+                    response.raise_for_status()
+                    history_details = parse_response(response)
+                    creation_date = datetime.strptime(history_details["Created"], "%Y-%m-%d %H:%M:%S")
+                    logging.debug(f"#{ticket} was created on {creation_date}")
+                    # only increment number of created tickets if the creation came during the time period
+                    if (creation_date >= datetime.fromtimestamp(args.start)) and (creation_date <= datetime.fromtimestamp(args.end)):
+                        tickets_created += 1
+
+                # check if ticket assigned for the first time
+                if not assigned and (ticket_type == "Taken by" or ticket_type == "Given to"):
+                    assigned = True
+                    response = session.get(args.api_uri + f"/ticket/{ticket}/history/id/{history_id}")
+                    response.raise_for_status()
+                    history_details = parse_response(response)
+                    assign_date = datetime.strptime(history_details["Created"], "%Y-%m-%d %H:%M:%S")
+                    logging.debug(f"#{ticket} was first assigned on {assign_date}")
+                    # only increment number of assigned tickets if the first assignment came during the time period
+                    if (assign_date >= datetime.fromtimestamp(args.start)) and (assign_date <= datetime.fromtimestamp(args.end)):
+                        tickets_assigned += 1
+
+                # check if email exchanged
+                if ticket_type in {"Ticket created", "Correspondence added"}:
+                    response = session.get(args.api_uri + f"/ticket/{ticket}/history/id/{history_id}")
+                    response.raise_for_status()
+                    history_details = parse_response(response)
+                    sent_date = datetime.strptime(history_details["Created"], "%Y-%m-%d %H:%M:%S")
+                    sender = history[history_id].split()[-1]
+                    logging.debug(f"#{ticket} had email sent by {sender} on {sent_date}")
+
+                    # ignore if outside time period
+                    if (sent_date < datetime.fromtimestamp(args.start)) or (sent_date > datetime.fromtimestamp(args.end)):
+                        continue
+
+                    if "@" in sender: # from outside CHTC
+                        emails_recv += 1
+
+                        if last_recv is None: # store sent time (unless it's a followup)
+                            last_recv = sent_date
+
+                    else: # from inside CHTC
+                        emails_sent += 1
+                        last_sent = sent_date
+
+                        if last_recv is not None: # compute delta from receive time
+                            dt = last_sent - last_recv
+                            response_times.append(dt.total_seconds())
+                            last_recv = None # make sure not to recompute if followed up
+
+        with open(args.outdir / f"rt_data_{queue}.txt", "w") as f:
+            f.write(f"From {datetime.fromtimestamp(args.start)} to {datetime.fromtimestamp(args.end)}:\n")
+            f.write(f"{tickets_created} new requests for assistance through our ticket-tracked\n")
+            f.write(f"{queue} support system were addressed by {emails_recv + emails_sent} email communications.\n")
+            f.write(f"\n")
+            f.write(f"PATh staff were newly assigned {tickets_assigned} tickets,\n")
+            f.write(f"users sent {emails_recv} emails,\n")
+            f.write(f"and PATh staff sent {emails_sent} emails.\n")
+            f.write(f"The average PATh staff response time to mail received was {(sum(response_times)/(len(response_times)+1e-12))/3600:0.1f} hours.\n")
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--outdir", default=OUTDIR, metavar="PATH", type=Path, help="Output directory, defaults to CWD (%(default)s)")
+    parser.add_argument("--start", default=START_TS, metavar="TIMESTAMP", type=int, help="Starting timestamp, defaults to one week ago (%(default)d)")
+    parser.add_argument("--end", default=END_TS, metavar="TIMESTAMP", type=int, help="Ending timestamp, defaults to now (%(default)d)")
+    parser.add_argument("--log_level", metavar="LEVEL", default="WARNING", help="Log level, defaults to %(default)s")
+    parser.add_argument("--queue", default=["htcondor-admin"], action="append", dest="queues", help="Queues to query, can be specified multiple times, defaults to %(default)s")
+    parser.add_argument("--api_uri", help="RT API URI", required=True)
+    parser.add_argument("--username", help="RT API username", required=True)
+    parser.add_argument("--password_file", type=Path, help="File containing RT API password", required=True)
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parse_args()
+    logging.getLogger().setLevel(getattr(logging, args.log_level.upper(), logging.WARNING))
+    session = get_session(args)
+    get_and_write_data(session, args)
+
+if __name__ == "__main__":
+    main()

--- a/afs/extract_version_history.py
+++ b/afs/extract_version_history.py
@@ -1,0 +1,158 @@
+import sys
+import logging
+import argparse
+import subprocess
+import shlex
+import shutil
+from collections import defaultdict
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+
+OUTDIR = Path.cwd()
+
+def get_latest_version_history_files(doc_dir):
+    devel_files = doc_dir.glob("development-release-series-*.rst")
+    stable_files = doc_dir.glob("stable-release-series-*.rst")
+
+    devel_versions = [f.stem.split("-")[-1] for f in devel_files]
+    stable_versions = [f.stem.split("-")[-1] for f in stable_files]
+
+    # Assume for now that bigger numbers are newer...
+    devel_versions.sort(key=int, reverse=True)
+    stable_versions.sort(key=int, reverse=True)
+
+    latest_devel_file = doc_dir / f"development-release-series-{devel_versions[0]}.rst"
+    latest_stable_file = doc_dir / f"stable-release-series-{stable_versions[0]}.rst"
+
+    return [latest_devel_file, latest_stable_file]
+
+def get_version_history_files(doc_dir, versions):
+    version_history_files = []
+    for version in versions:
+        major_ver_nodot = "".join(version.split(".")[:2])
+        glob = f"*-release-series-{major_ver_nodot}.rst"
+        matched_files = list(doc_dir.glob(glob))
+        if len(matched_files) == 0:
+            logging.error(f"Found no version history file for {version} (matching: {glob})")
+            logging.error(f"Skipping version {version}")
+            continue
+        elif len(matched_files) > 1:
+            logging.error(f"Found multiple version history files for {version} (matching: {glob})")
+            logging.error(f"Skipping version {version}")
+            continue
+        else:
+            version_history_files += matched_files
+    return version_history_files
+
+def read_docs(args):
+    doc_dir = args.repo_dir / "docs" / "version-history"
+
+    # Get a list of history files to parse
+    if args.versions is None:
+        version_history_files = get_latest_version_history_files(doc_dir)
+    else:
+        version_history_files = get_version_history_files(doc_dir, args.versions)
+    if len(version_history_files) == 0:
+        logging.error("Could not find any version history files!")
+        sys.exit(1)
+
+    # data is two level defaultdict with int data:
+    # 1. Version tuple
+    # 2. Section (release notes, new features, bugs fixed)
+    data = defaultdict(lambda: defaultdict(int))
+    doc_type = {
+        "release notes:": "notes",
+        "new features:": "features",
+        "bugs fixed:": "bugfixes",
+    }
+
+    # Make a list of version tuples from requested versions (if they exist)
+    store_versions = None
+    if args.versions is not None:
+        store_versions = [tuple([int(x) for x in v.split(".")]) for v in args.versions]
+
+    for version_history_file in version_history_files:
+        with open(version_history_file) as f:
+            n = 0
+            version = None
+            section = None
+            for line in f:
+                n += 1
+
+                # Skip empty lines
+                if line.rstrip() == "":
+                    continue
+
+                # Skip until we get a version
+                if line.startswith("Version "):
+                    version = tuple([int(x) for x in line.rstrip().split()[1].split(".")])
+                    logging.info(f"Got {line.rstrip()} {version}")
+                    section = None
+                    continue
+                elif version is None:
+                    continue
+
+                # Skip versions that aren't requested to be stored
+                if store_versions is not None and version not in store_versions:
+                    continue
+
+                # Skip until we get a section
+                if line.rstrip().lower() in doc_type:
+                    section = doc_type[line.rstrip().lower()]
+                    logging.info(f"Got section {line.rstrip()}")
+                    continue
+                elif section is None:
+                    continue
+
+                # Count all entries
+                if line.startswith("- "):
+                    if line.rstrip() == "- None.":
+                        continue
+                    data[version][section] += 1
+
+        logging.info(f"Read {n} lines from {version_history_file}")
+
+    return data
+
+def write_csv(data, args):
+    versions = list(data.keys())
+    versions.sort(reverse=True)
+
+    # Get version strings
+    version_strs = [".".join([str(x) for x in v]) for v in versions]
+
+    cols = ["bugfixes", "features"]
+
+    with open(args.outdir / "documented_changes_by_version.csv", "w") as f:
+        f.write(f"version,{','.join(cols)}\n")
+        for version, version_str in zip(versions, version_strs):
+            f.write(f"{version_str},{','.join([str(data[version][col]) for col in cols])}\n")
+
+    with open(args.outdir / "version_history_data.txt", "w") as f:
+        f.write(f"As of {datetime.now()}:\n")
+        for version, version_str in zip(versions, version_strs):
+            f.write(f"Version {version_str} had\n")
+            f.write(f"\t{data[version]['features']} documented enhancements and\n")
+            f.write(f"\t{data[version]['bugfixes']} documented bug fixes.\n")
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--outdir", default=OUTDIR, metavar="PATH", type=Path, help="Output directory, defaults to CWD (%(default)s)")
+    parser.add_argument("--log_level", metavar="LEVEL", default="WARNING", help="Log level, defaults to %(default)s")
+    parser.add_argument("--version", metavar="VERSION", action="append", dest="versions",
+        help=("Version to output stats for, can be specified multiple times. "
+            "Defaults to outputting all versions in latest stable and devel series if not specified"))
+    parser.add_argument("--repo_dir", metavar="PATH", type=Path, required=True,
+        help="Path to existing CONDOR_SRC repository. Must be updated and set to correct branch.")
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parse_args()
+    logging.getLogger().setLevel(getattr(logging, args.log_level.upper(), logging.WARNING))
+    data = read_docs(args)
+    write_csv(data, args)
+
+if __name__ == "__main__":
+    main()

--- a/afs/lines-of-code.sh
+++ b/afs/lines-of-code.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ "$#" -ne "1" ]; then
+    echo "$0 requires a path to a source code directory as its lone argument" 1>&2
+    exit 1
+fi
+
+SOURCE_DIR="$1"
+
+for dir in $(find "$SOURCE_DIR" -maxdepth 1 -type d -not -path '*.git'); do
+    dirname="$(basename $dir)"
+    if [ "$SOURCE_DIR" = "$dir" ]; then
+	loc=$(find "$dir" -maxdepth 1 -type f -exec \
+	    wc -l {} \; | awk '{total += $1} END {print total}')
+    else
+	loc=$(find "$dir" -type f -exec \
+	    wc -l {} \; | awk '{total += $1} END {print total}')
+    fi
+    echo "$dirname: $loc"
+done

--- a/afs/requirements.txt
+++ b/afs/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/afs/weekly-afs-metrics-update.sh
+++ b/afs/weekly-afs-metrics-update.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -e
+
+#####
+# The following should be set in the config file ~/.weekly-afs-metrics.config.sh
+# RT_USER              - A readonly RT service account username
+# RT_PASSWORD_FILE     - Path to a file containing the password for RT_USER
+# RT_API_URI           - The base URI of the RT REST API (ends in REST/1.0)
+# CONDOR_SRC_REPO_DIR  - Path to up-to-date copy of the CONDOR_SRC repo pointed
+#     at the master branch. **The onus is on you to keep this repo up to date!**
+CONFIG_FILE="$HOME/.weekly-afs-metrics-config.sh"
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Could not find $CONFIG_FILE, exiting..." 1>&2
+    exit 1
+fi
+. $CONFIG_FILE
+if [ -z "$RT_USER" ] || \
+   [ -z "$RT_PASSWORD_FILE" ] || \
+   [ -z "$RT_API_URI" ] || \
+   [ -z "$CONDOR_SRC_REPO_DIR" ]; then
+    echo "One or more required variables are missing from $CONFIG_FILE" 1>&2
+    exit 1
+fi
+#####
+
+cd "$(dirname "$0")"
+
+# venv setup (requests is needed for RT REST API queries)
+
+python3 -m venv venv 1>&2
+. venv/bin/activate
+pip install -r requirements.txt 1>&2
+
+# run metrics
+
+OUTDIR="data-$(date +%F)"
+START_DATE=$(date -d "-1 week 12 AM" +%s)
+END_DATE=$(date -d "today 12 AM" +%s)
+
+if [ ! -d "$OUTDIR" ]; then
+   mkdir -p "$OUTDIR"
+fi
+
+echo "Running extract_download_data.py" 1>&2
+python extract_download_data.py \
+       --outdir="$OUTDIR" --start=$START_DATE --end=$END_DATE
+
+echo "Running extract_git_data.py" 1>&2
+python extract_git_data.py \
+       --outdir="$OUTDIR" --start=$START_DATE --end=$END_DATE \
+       --repo_dir="$CONDOR_SRC_REPO_DIR"
+
+echo "Running extract_htcondor_users_data.py" 1>&2
+python extract_htcondor_users_data.py \
+       --outdir="$OUTDIR" --start=$START_DATE --end=$END_DATE
+
+echo "Running extract_rt_stats.py" 1>&2
+python extract_rt_stats.py \
+       --outdir="$OUTDIR" --start=$START_DATE --end=$END_DATE \
+       --queue="htcondor-admin" \
+       --api_uri="$RT_API_URI" --username="$RT_USER" --password_file="$RT_PASSWORD_FILE"
+
+echo "Running extract_version_history.py" 1>&2
+python extract_version_history.py \
+       --outdir="$OUTDIR" \
+       --repo_dir="$CONDOR_SRC_REPO_DIR"
+echo 1>&2
+
+# print metrics
+
+echo "==========================="
+echo "=== Download statistics ==="
+echo "==========================="
+echo
+cat "$OUTDIR/download_data.txt"
+echo
+echo "==========================="
+echo "=== Codebase statistics ==="
+echo "==========================="
+echo
+cat "$OUTDIR/git_data.txt"
+echo
+echo "================================="
+echo "=== HTCondor-Users statistics ==="
+echo "================================="
+echo
+cat "$OUTDIR/htcondor-users_data.txt"
+echo
+echo "================================="
+echo "=== HTCondor-Admin statistics ==="
+echo "================================="
+echo
+cat "$OUTDIR/rt_data_htcondor-admin.txt"
+echo
+echo "=================================="
+echo "=== Version History statistics ==="
+echo "=================================="
+echo
+cat "$OUTDIR/version_history_data.txt"


### PR DESCRIPTION
These scripts all require AFS access (except `extract_git_data.py`
and `extract_version_history.py`, which require an up-to-date
`CONDOR_SRC` git repo, so might as well live adjacent to AFS).

Config should be placed in `~/.weekly-afs-metrics-config.sh`
following the instructions in `weekly-afs-metrics-update.sh`.
Suggested values for the config file will be placed in the wiki.

`weekly-afs-metrics-update.sh` is the wrapper script around all
of the other scripts in here, and will create a Python 3 virtualenv
containing the `requests` library (needed for querying the RT API).